### PR TITLE
add support to python3.8 and run tests against 2.7, 3.7, 3.8 using tox.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.pyc
 *.swp
 *.swo
+
+.coverage
+.tox
+htmlcov

--- a/README.rst
+++ b/README.rst
@@ -70,3 +70,11 @@ LAST_SEEN_INTERVAL
     How often is the last seen timestamp updated to the
     database. The default is 2 hours.
 
+
+Development (using python3)
+=====
+
+```
+$ pip install tox
+$ tox
+```

--- a/last_seen/admin.py
+++ b/last_seen/admin.py
@@ -1,7 +1,9 @@
-
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
 from django.contrib import admin
 
-from models import LastSeen
+from .models import LastSeen
 
 
 class LastSeenAdmin(admin.ModelAdmin):

--- a/last_seen/middleware.py
+++ b/last_seen/middleware.py
@@ -1,6 +1,7 @@
-
-
-from models import user_seen
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from .models import user_seen
 
 
 class LastSeenMiddleware(object):

--- a/last_seen/models.py
+++ b/last_seen/models.py
@@ -1,11 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
 import time
 import datetime
-from django.db import models
 from django.contrib.sites.models import Site
-from django.utils import timezone
 from django.core.cache import cache
+from django.db import models
+from django.utils import timezone
+from django.utils.encoding import python_2_unicode_compatible
 
-import settings
+from . import settings
 
 
 class LastSeenManager(models.Manager):
@@ -54,6 +58,7 @@ class LastSeenManager(models.Manager):
         return self.filter(**args).latest('last_seen').last_seen
 
 
+@python_2_unicode_compatible
 class LastSeen(models.Model):
     site = models.ForeignKey(Site)
     user = models.ForeignKey(settings.AUTH_USER_MODEL)
@@ -67,8 +72,8 @@ class LastSeen(models.Model):
         unique_together = (('user', 'site', 'module'),)
         ordering = ('-last_seen',)
 
-    def __unicode__(self):
-        return u"%s on %s" % (self.user, self.last_seen)
+    def __str__(self):
+        return "%s on %s" % (self.user, self.last_seen)
 
 
 def get_cache_key(site, module, user):

--- a/last_seen/settings.py
+++ b/last_seen/settings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from django.conf import settings
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
-import os
+from __future__ import unicode_literals
 from distutils.core import setup
+import os
 
-__author__ = u'Ferran Pegueroles'
-__copyright__ = u'Copyright 2013, Ferran Pegueroles'
-__credits__ = [u'Ferran Pegueroles']
+__author__ = 'Ferran Pegueroles'
+__copyright__ = 'Copyright 2013, Ferran Pegueroles'
+__credits__ = ['Ferran Pegueroles']
 
 
 __license__ = 'GPL'
-__version__ = '0.3'
+__version__ = '0.4'
 __email__ = 'ferran@pegueroles.com'
 
 

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 # Django settings for test_project project.
 
 DEBUG = True
@@ -29,7 +32,6 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     # Uncomment the next line to enable admin documentation:
     # 'django.contrib.admindocs',
-    'south',
     'last_seen',
 )
 
@@ -45,3 +47,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'last_seen.middleware.LastSeenMiddleware',
 )
+
+
+SECRET_KEY = 'secret'

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 from django.conf.urls import include, url
 from last_seen.models import clear_interval
 from django.shortcuts import redirect

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+coverage==5.1
+Django==1.11.29
+mock==3.0.5
+six==1.14.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist =
+    py27
+    py37
+    py38
+
+[testenv]
+deps =
+    -rtest_requirements.txt
+commands =
+    ./runtests.sh


### PR DESCRIPTION
* make code py3 compatible
* manage.py now requires a non-empty SECRET_KEY, so add one to test_project/settings.py
* autospec looks into `DefaultCacheProxy` for public attributes and finds nothing as it's purely a proxy object.
* use tox to test against different python versions